### PR TITLE
Refactor update logic with helper functions

### DIFF
--- a/B01 Auto Splitter (plutonium).asl
+++ b/B01 Auto Splitter (plutonium).asl
@@ -6,28 +6,49 @@
 //   Verrückt:      Alive=7,  Dead=25
 //   Der Riese:     Alive=129,Dead=26
 //
-// menu_state: 0 = playing, 99 = main menu (treat any != 0 as menu/loading)
+// menu_state values:
+//   MENU_STATE_PLAYING = 0
+//   MENU_STATE_MAIN    = 99
 // timer: ~20 units/sec, resets near 0 (map restart makes it drop/reset)
 // game_paused: > 0 = paused, 0 = playing
 
+const int MENU_STATE_PLAYING = 0;
+const int MENU_STATE_MAIN    = 99;
+
+const int MENU_STATE_ADDR  = 0x7CB530;
+const int TIMER_ADDR       = 0x168A37C;
+const int GAME_PAUSED_ADDR = 0x216BFD0;
+const int DEAD_ADDR        = 0x1656C38;
+
 state("plutonium-bootstrapper-win32")
 {
-    int  menu_state  : 0x7CB530;
-    int  timer       : 0x168A37C;
-    int  game_paused : 0x216BFD0;
-    int  dead        : 0x1656C38;
+    int  menu_state  : MENU_STATE_ADDR;
+    int  timer       : TIMER_ADDR;
+    int  game_paused : GAME_PAUSED_ADDR;
+    int  dead        : DEAD_ADDR;
 }
 
 init { refreshRate = 20; }
 
+settings
+{
+    // ---- Tunables ----
+    "T_START_THRESHOLD"     : 50
+    "T_RESET_SMALL"         : 100
+    "PauseConfirmTicks"     : 3
+    "UseStallPause"         : false
+    "T_TIMER_STALL_TICKS"   : 3
+    "T_RESUME_TICKS"        : 2
+}
+
 startup
 {
     // ---- Tunables ----
-    vars.T_START_THRESHOLD       = 50;   // start once in-game timer >= 50 (~2.5s @ ~20/s)
-    vars.T_RESET_SMALL           = 100;  // "fresh" timer threshold for menu-based detection
+    vars.T_START_THRESHOLD       = (int)settings["T_START_THRESHOLD"];     // start once in-game timer >= 50 (~2.5s @ ~20/s)
+    vars.T_RESET_SMALL           = (int)settings["T_RESET_SMALL"];         // "fresh" timer threshold for menu-based detection
     vars.T_RESET_CONFIRM_TICKS   = 20;   // ~1s 20 Hz (menu-based fresh-game arm)
 
-    vars.PauseConfirmTicks       = 3;    // debounce explicit pause
+    vars.PauseConfirmTicks       = (int)settings["PauseConfirmTicks"];     // debounce explicit pause
     vars.UnpauseConfirmTicks     = 3;    // debounce explicit unpause
 
     // Death handling (debounce)
@@ -35,9 +56,9 @@ startup
     vars.AliveConfirmTicks       = 5;    // ~250ms alive confirm before allowing new start
 
     // Stall-based pause (kept OFF for better pause behavior)
-    vars.UseStallPause           = false;
-    vars.T_TIMER_STALL_TICKS     = 3;
-    vars.T_RESUME_TICKS          = 2;
+    vars.UseStallPause           = (bool)settings["UseStallPause"];
+    vars.T_TIMER_STALL_TICKS     = (int)settings["T_TIMER_STALL_TICKS"];
+    vars.T_RESUME_TICKS          = (int)settings["T_RESUME_TICKS"];
 
     // ---- Timer model + flags ----
     vars.timerModel = new TimerModel { CurrentState = timer };
@@ -68,9 +89,9 @@ startup
 
     // ---- Map alive/death codes ----
     // Alive values across maps
-    vars.AliveVals = new List<int> { 0, 7, 129 };
+    vars.AliveVals = new HashSet<int> { 0, 7, 129 };
     // Dead values across maps
-    vars.DeadVals  = new List<int> { 5, 25, 26 };
+    vars.DeadVals  = new HashSet<int> { 5, 25, 26 };
 }
 
 // Start — only when alive, in gameplay, and timer is moving
@@ -78,7 +99,7 @@ start
 {
     if (vars.pendingReset) return false;                       // don't start while a reset is queued
     if (vars.blockStartUntilAlive || !vars.AliveVals.Contains(current.dead)) return false; // must be alive
-    if (current.menu_state != 0) return false;                // must be in gameplay
+    if (current.menu_state != MENU_STATE_PLAYING) return false; // must be in gameplay
 
     if (current.timer > old.timer && current.timer >= vars.T_START_THRESHOLD)
     {
@@ -121,93 +142,79 @@ reset
         return true;
     }
 
-    if (current.menu_state != 0 || current.timer > vars.T_RESET_SMALL)
+    if (current.menu_state != MENU_STATE_PLAYING || current.timer > vars.T_RESET_SMALL)
         vars.did_reset = false;
 
     return false;
 }
 
-// Update — pause/unpause, stop on death/menu, HARD reset on map restart, arm resets
-update
+// 1) Debounced pause/unpause from explicit pause flag (>0 = paused)
+bool handlePauseToggle(bool toggledThisTick)
 {
-    bool toggledThisTick = false;
+    if (!vars.timer_started)
+        return toggledThisTick;
 
-    // 0) Track alive stability to clear start-block after death
-    if (vars.AliveVals.Contains(current.dead))
+    bool gameIsPaused = (current.game_paused > 0);
+
+    if (gameIsPaused) { vars.pauseHold++;  vars.unpauseHold = 0; }
+    else              { vars.unpauseHold++; vars.pauseHold  = 0; }
+
+    if (!vars.is_paused && vars.pauseHold >= vars.PauseConfirmTicks)
     {
-        vars.aliveStableTicks++;
-        if (vars.blockStartUntilAlive && vars.aliveStableTicks >= vars.AliveConfirmTicks)
-            vars.blockStartUntilAlive = false; // allow future starts again
+        vars.timerModel.Pause(); // ON
+        vars.is_paused = true;
+        vars.stallPauseActive = false;
+        vars.stallTicks = vars.resumeTicks = 0;
+        toggledThisTick = true;
     }
-    else
+
+    if (!toggledThisTick && vars.is_paused && !vars.stallPauseActive &&
+        vars.unpauseHold >= vars.UnpauseConfirmTicks)
     {
-        vars.aliveStableTicks = 0;
+        vars.timerModel.Pause(); // OFF
+        vars.is_paused = false;
+        toggledThisTick = true;
     }
 
-    // 1) Debounced pause/unpause from explicit pause flag (>0 = paused)
-    if (vars.timer_started)
+    return toggledThisTick;
+}
+
+// 2) Stall-based pause (off unless enabled)
+bool handleStallPause(bool toggledThisTick)
+{
+    if (!(vars.UseStallPause && vars.timer_started && !toggledThisTick && (current.game_paused == 0)))
+        return toggledThisTick;
+
+    if (current.timer <= old.timer) vars.stallTicks++; else { vars.stallTicks = 0; vars.resumeTicks = 0; }
+
+    if (!vars.is_paused && vars.stallTicks >= vars.T_TIMER_STALL_TICKS)
     {
-        bool gameIsPaused = (current.game_paused > 0);
+        vars.timerModel.Pause(); // ON
+        vars.is_paused = true;
+        vars.stallPauseActive = true;
+        vars.resumeTicks = 0;
+        return true;
+    }
 
-        if (gameIsPaused) { vars.pauseHold++;  vars.unpauseHold = 0; }
-        else              { vars.unpauseHold++; vars.pauseHold  = 0; }
-
-        if (!vars.is_paused && vars.pauseHold >= vars.PauseConfirmTicks)
-        {
-            vars.timerModel.Pause(); // ON
-            vars.is_paused = true;
-            vars.stallPauseActive = false;
-            vars.stallTicks = vars.resumeTicks = 0;
-            toggledThisTick = true;
-        }
-
-        if (!toggledThisTick && vars.is_paused && !vars.stallPauseActive &&
-            vars.unpauseHold >= vars.UnpauseConfirmTicks)
+    if (vars.is_paused && vars.stallPauseActive && current.timer > old.timer)
+    {
+        vars.resumeTicks++;
+        if (vars.resumeTicks >= vars.T_RESUME_TICKS)
         {
             vars.timerModel.Pause(); // OFF
             vars.is_paused = false;
-            toggledThisTick = true;
+            vars.stallPauseActive = false;
+            vars.stallTicks = vars.resumeTicks = 0;
+            return true;
         }
     }
 
-    // 2) stall-based pause (off unless enabled)
-    if (vars.UseStallPause && vars.timer_started && !toggledThisTick && (current.game_paused == 0))
-    {
-        if (current.timer <= old.timer) vars.stallTicks++; else { vars.stallTicks = 0; vars.resumeTicks = 0; }
+    return toggledThisTick;
+}
 
-        if (!vars.is_paused && vars.stallTicks >= vars.T_TIMER_STALL_TICKS)
-        {
-            vars.timerModel.Pause(); // ON
-            vars.is_paused = true;
-            vars.stallPauseActive = true;
-            vars.resumeTicks = 0;
-            toggledThisTick = true;
-        }
-
-        if (!toggledThisTick && vars.is_paused && vars.stallPauseActive && current.timer > old.timer)
-        {
-            vars.resumeTicks++;
-            if (vars.resumeTicks >= vars.T_RESUME_TICKS)
-            {
-                vars.timerModel.Pause(); // OFF
-                vars.is_paused = false;
-                vars.stallPauseActive = false;
-                vars.stallTicks = vars.resumeTicks = 0;
-            }
-        }
-    }
-
-    // 3) Stop on leaving gameplay (menu_state != 0) → pause + queued reset
-    if (vars.timer_started && current.menu_state != 0)
-    {
-        if (!vars.is_paused) { vars.timerModel.Pause(); vars.is_paused = true; } // freeze immediately
-        vars.timer_started = false;
-        vars.hasStoppedOnce = true;
-        vars.pendingReset = true;   // reset via reset{} next tick
-        vars.pauseHold = vars.unpauseHold = 0;
-    }
-
-    // 4) Stop on death → pause + queued reset; block starts until alive confirmed
+// Stop on death → pause + queued reset; block starts until alive confirmed
+void checkDeathReset()
+{
     if (vars.timer_started)
     {
         bool isDeadNow = vars.DeadVals.Contains(current.dead);
@@ -226,9 +233,42 @@ update
             vars.aliveStableTicks = 0;
         }
     }
+}
+
+// Update — pause/unpause, stop on death/menu, HARD reset on map restart, arm resets
+update
+{
+    // 0) Track alive stability to clear start-block after death
+    if (vars.AliveVals.Contains(current.dead))
+    {
+        vars.aliveStableTicks++;
+        if (vars.blockStartUntilAlive && vars.aliveStableTicks >= vars.AliveConfirmTicks)
+            vars.blockStartUntilAlive = false; // allow future starts again
+    }
+    else
+    {
+        vars.aliveStableTicks = 0;
+    }
+
+    bool toggledThisTick = false;
+    toggledThisTick = handlePauseToggle(toggledThisTick);
+    toggledThisTick = handleStallPause(toggledThisTick);
+
+    // 3) Stop on leaving gameplay (menu_state != MENU_STATE_PLAYING) → pause + queued reset
+    if (vars.timer_started && current.menu_state != MENU_STATE_PLAYING)
+    {
+        if (!vars.is_paused) { vars.timerModel.Pause(); vars.is_paused = true; } // freeze immediately
+        vars.timer_started = false;
+        vars.hasStoppedOnce = true;
+        vars.pendingReset = true;   // reset via reset{} next tick
+        vars.pauseHold = vars.unpauseHold = 0;
+    }
+
+    // 4) Stop on death → pause + queued reset; block starts until alive confirmed
+    checkDeathReset();
 
     // 4b) HARD map restart: timer decreased while still in gameplay (reset even at 1–2s)
-    if (current.menu_state == 0 && current.timer < old.timer)
+    if (current.menu_state == MENU_STATE_PLAYING && current.timer < old.timer)
     {
         // Immediate LiveSplit reset to 0.00
         vars.timerModel.Reset();
@@ -250,7 +290,7 @@ update
     // 5) Fresh-game queued reset logic — kept for menu-based reloads only
     if (!vars.timer_started && vars.hasStoppedOnce &&
         !vars.pendingReset && !vars.did_reset &&
-        current.menu_state == 0 && current.timer <= vars.T_RESET_SMALL)
+        current.menu_state == MENU_STATE_PLAYING && current.timer <= vars.T_RESET_SMALL)
     {
         vars.freshGameConfirmTicks++;
         if (vars.freshGameConfirmTicks >= vars.T_RESET_CONFIRM_TICKS)
@@ -260,7 +300,7 @@ update
             vars.freshGameConfirmTicks = 0;
         }
     }
-    else if (current.timer > vars.T_RESET_SMALL || current.menu_state != 0 || vars.pendingReset || vars.did_reset)
+    else if (current.timer > vars.T_RESET_SMALL || current.menu_state != MENU_STATE_PLAYING || vars.pendingReset || vars.did_reset)
     {
         if (!vars.timer_started)
             vars.freshGameConfirmTicks = 0;


### PR DESCRIPTION
## Summary
- restore settings-based configuration and address constants
- keep HashSet lookups for alive/dead codes
- refactor `update` with helper functions `handlePauseToggle`, `handleStallPause`, and `checkDeathReset`
- ensure gameplay exit pauses and queues reset before death handling

## Testing
- `echo 'No tests to run'`


------
https://chatgpt.com/codex/tasks/task_e_689fedbd95f08330a175da2aadb069c5