### PR TITLE
Expose tunables and refactor autosplitter logic

### DIFF
--- a/B01 Auto Splitter (plutonium).asl
+++ b/B01 Auto Splitter (plutonium).asl
@@ -23,21 +23,41 @@ init { refreshRate = 20; }
 startup
 {
     // ---- Tunables ----
-    vars.T_START_THRESHOLD       = 50;   // start once in-game timer >= 50 (~2.5s @ ~20/s)
-    vars.T_RESET_SMALL           = 100;  // "fresh" timer threshold for menu-based detection
-    vars.T_RESET_CONFIRM_TICKS   = 20;   // ~1s 20 Hz (menu-based fresh-game arm)
+    // Start once in-game timer >= value (~2.5s @ ~20/s)
+    settings.AddInt("T_START_THRESHOLD", 50, "Start threshold");
+    vars.T_START_THRESHOLD = (int)settings["T_START_THRESHOLD"];
 
-    vars.PauseConfirmTicks       = 3;    // debounce explicit pause
-    vars.UnpauseConfirmTicks     = 3;    // debounce explicit unpause
+    // "Fresh" timer threshold for menu-based detection
+    settings.AddInt("T_RESET_SMALL", 100, "Fresh timer threshold");
+    vars.T_RESET_SMALL = (int)settings["T_RESET_SMALL"];
 
-    // Death handling (debounce)
-    vars.DeathConfirmTicks       = 5;    // ~250ms to confirm death
-    vars.AliveConfirmTicks       = 5;    // ~250ms alive confirm before allowing new start
+    // ~1s @20Hz (menu-based fresh-game arm)
+    settings.AddInt("T_RESET_CONFIRM_TICKS", 20, "Fresh-game confirm ticks");
+    vars.T_RESET_CONFIRM_TICKS = (int)settings["T_RESET_CONFIRM_TICKS"];
 
-    // Stall-based pause (kept OFF for better pause behavior)
-    vars.UseStallPause           = false;
-    vars.T_TIMER_STALL_TICKS     = 3;
-    vars.T_RESUME_TICKS          = 2;
+    // Debounce explicit pause/unpause
+    settings.AddInt("PauseConfirmTicks", 3, "Pause debounce ticks");
+    vars.PauseConfirmTicks = (int)settings["PauseConfirmTicks"];
+
+    settings.AddInt("UnpauseConfirmTicks", 3, "Unpause debounce ticks");
+    vars.UnpauseConfirmTicks = (int)settings["UnpauseConfirmTicks"];
+
+    // Death handling (debounce) ~250ms @20Hz
+    settings.AddInt("DeathConfirmTicks", 5, "Death confirm ticks");
+    vars.DeathConfirmTicks = (int)settings["DeathConfirmTicks"];
+
+    settings.AddInt("AliveConfirmTicks", 5, "Alive confirm ticks");
+    vars.AliveConfirmTicks = (int)settings["AliveConfirmTicks"];
+
+    // Stall-based pause detection
+    settings.AddBool("UseStallPause", false, "Enable stall-based pause");
+    vars.UseStallPause = (bool)settings["UseStallPause"];
+
+    settings.AddInt("T_TIMER_STALL_TICKS", 3, "Timer stall ticks");
+    vars.T_TIMER_STALL_TICKS = (int)settings["T_TIMER_STALL_TICKS"];
+
+    settings.AddInt("T_RESUME_TICKS", 2, "Resume ticks after stall");
+    vars.T_RESUME_TICKS = (int)settings["T_RESUME_TICKS"];
 
     // ---- Timer model + flags ----
     vars.timerModel = new TimerModel { CurrentState = timer };
@@ -68,9 +88,9 @@ startup
 
     // ---- Map alive/death codes ----
     // Alive values across maps
-    vars.AliveVals = new List<int> { 0, 7, 129 };
+    vars.AliveVals = new HashSet<int> { 0, 7, 129 };
     // Dead values across maps
-    vars.DeadVals  = new List<int> { 5, 25, 26 };
+    vars.DeadVals  = new HashSet<int> { 5, 25, 26 };
 }
 
 // Start — only when alive, in gameplay, and timer is moving
@@ -94,30 +114,33 @@ start
 // Base script: no splits
 split { return false; }
 
+void ClearLocalState()
+{
+    vars.timer_started = false;
+    vars.is_paused = false;
+
+    vars.timer_value = 0;
+    vars.timer_pause_length = 0;
+
+    vars.pauseHold = vars.unpauseHold = 0;
+    vars.stallTicks = vars.resumeTicks = 0;
+    vars.stallPauseActive = false;
+
+    // Keep aliveStableTicks/blockStartUntilAlive as-is
+    vars.deathStableTicks = 0;
+    vars.freshGameConfirmTicks = 0;
+
+    vars.pendingReset = false;
+    vars.did_reset = true;
+    vars.hasStoppedOnce = false;
+}
+
 // Reset — executes only when update() sets vars.pendingReset (menu/death path)
 reset
 {
     if (vars.pendingReset)
     {
-        // Clear local state
-        vars.timer_started = false;
-        vars.is_paused = false;
-
-        vars.timer_value = 0;
-        vars.timer_pause_length = 0;
-
-        vars.pauseHold = vars.unpauseHold = 0;
-        vars.stallTicks = vars.resumeTicks = 0;
-        vars.stallPauseActive = false;
-
-        // Keep aliveStableTicks/blockStartUntilAlive (death path) as-is;
-        // we want to require a stable alive state before re-starting.
-        vars.deathStableTicks = 0;
-        vars.freshGameConfirmTicks = 0;
-
-        vars.pendingReset = false;
-        vars.did_reset = true;
-        vars.hasStoppedOnce = false;
+        ClearLocalState();
         return true;
     }
 
@@ -132,7 +155,20 @@ update
 {
     bool toggledThisTick = false;
 
-    // 0) Track alive stability to clear start-block after death
+    TrackAliveStability();
+    HandleExplicitPause(ref toggledThisTick);
+    HandleStallPause(ref toggledThisTick);
+    HandleMenuExit();
+    HandleDeathReset();
+    HandleHardRestart();
+    HandleFreshGameReset();
+    UpdatePauseStrippedClock();
+
+    return true;
+}
+
+void TrackAliveStability()
+{
     if (vars.AliveVals.Contains(current.dead))
     {
         vars.aliveStableTicks++;
@@ -143,61 +179,67 @@ update
     {
         vars.aliveStableTicks = 0;
     }
+}
 
-    // 1) Debounced pause/unpause from explicit pause flag (>0 = paused)
-    if (vars.timer_started)
+void HandleExplicitPause(ref bool toggledThisTick)
+{
+    if (!vars.timer_started) return;
+
+    bool gameIsPaused = (current.game_paused > 0);
+
+    if (gameIsPaused) { vars.pauseHold++;  vars.unpauseHold = 0; }
+    else              { vars.unpauseHold++; vars.pauseHold  = 0; }
+
+    if (!vars.is_paused && vars.pauseHold >= vars.PauseConfirmTicks)
     {
-        bool gameIsPaused = (current.game_paused > 0);
+        vars.timerModel.Pause(); // ON
+        vars.is_paused = true;
+        vars.stallPauseActive = false;
+        vars.stallTicks = vars.resumeTicks = 0;
+        toggledThisTick = true;
+    }
 
-        if (gameIsPaused) { vars.pauseHold++;  vars.unpauseHold = 0; }
-        else              { vars.unpauseHold++; vars.pauseHold  = 0; }
+    if (!toggledThisTick && vars.is_paused && !vars.stallPauseActive &&
+        vars.unpauseHold >= vars.UnpauseConfirmTicks)
+    {
+        vars.timerModel.Pause(); // OFF
+        vars.is_paused = false;
+        toggledThisTick = true;
+    }
+}
 
-        if (!vars.is_paused && vars.pauseHold >= vars.PauseConfirmTicks)
-        {
-            vars.timerModel.Pause(); // ON
-            vars.is_paused = true;
-            vars.stallPauseActive = false;
-            vars.stallTicks = vars.resumeTicks = 0;
-            toggledThisTick = true;
-        }
+void HandleStallPause(ref bool toggledThisTick)
+{
+    if (!vars.UseStallPause || !vars.timer_started || toggledThisTick || current.game_paused != 0)
+        return;
 
-        if (!toggledThisTick && vars.is_paused && !vars.stallPauseActive &&
-            vars.unpauseHold >= vars.UnpauseConfirmTicks)
+    if (current.timer <= old.timer) vars.stallTicks++;
+    else { vars.stallTicks = 0; vars.resumeTicks = 0; }
+
+    if (!vars.is_paused && vars.stallTicks >= vars.T_TIMER_STALL_TICKS)
+    {
+        vars.timerModel.Pause(); // ON
+        vars.is_paused = true;
+        vars.stallPauseActive = true;
+        vars.resumeTicks = 0;
+        toggledThisTick = true;
+    }
+
+    if (!toggledThisTick && vars.is_paused && vars.stallPauseActive && current.timer > old.timer)
+    {
+        vars.resumeTicks++;
+        if (vars.resumeTicks >= vars.T_RESUME_TICKS)
         {
             vars.timerModel.Pause(); // OFF
             vars.is_paused = false;
-            toggledThisTick = true;
+            vars.stallPauseActive = false;
+            vars.stallTicks = vars.resumeTicks = 0;
         }
     }
+}
 
-    // 2) stall-based pause (off unless enabled)
-    if (vars.UseStallPause && vars.timer_started && !toggledThisTick && (current.game_paused == 0))
-    {
-        if (current.timer <= old.timer) vars.stallTicks++; else { vars.stallTicks = 0; vars.resumeTicks = 0; }
-
-        if (!vars.is_paused && vars.stallTicks >= vars.T_TIMER_STALL_TICKS)
-        {
-            vars.timerModel.Pause(); // ON
-            vars.is_paused = true;
-            vars.stallPauseActive = true;
-            vars.resumeTicks = 0;
-            toggledThisTick = true;
-        }
-
-        if (!toggledThisTick && vars.is_paused && vars.stallPauseActive && current.timer > old.timer)
-        {
-            vars.resumeTicks++;
-            if (vars.resumeTicks >= vars.T_RESUME_TICKS)
-            {
-                vars.timerModel.Pause(); // OFF
-                vars.is_paused = false;
-                vars.stallPauseActive = false;
-                vars.stallTicks = vars.resumeTicks = 0;
-            }
-        }
-    }
-
-    // 3) Stop on leaving gameplay (menu_state != 0) → pause + queued reset
+void HandleMenuExit()
+{
     if (vars.timer_started && current.menu_state != 0)
     {
         if (!vars.is_paused) { vars.timerModel.Pause(); vars.is_paused = true; } // freeze immediately
@@ -206,48 +248,45 @@ update
         vars.pendingReset = true;   // reset via reset{} next tick
         vars.pauseHold = vars.unpauseHold = 0;
     }
+}
 
-    // 4) Stop on death → pause + queued reset; block starts until alive confirmed
-    if (vars.timer_started)
+void HandleDeathReset()
+{
+    if (!vars.timer_started) return;
+
+    bool isDeadNow = vars.DeadVals.Contains(current.dead);
+    if (isDeadNow) vars.deathStableTicks++; else vars.deathStableTicks = 0;
+
+    if (vars.deathStableTicks >= vars.DeathConfirmTicks)
     {
-        bool isDeadNow = vars.DeadVals.Contains(current.dead);
-        if (isDeadNow) vars.deathStableTicks++; else vars.deathStableTicks = 0;
+        if (!vars.is_paused) { vars.timerModel.Pause(); vars.is_paused = true; } // freeze immediately
+        vars.timer_started = false;
+        vars.hasStoppedOnce = true;
+        vars.pendingReset = true; // reset via reset{}
+        vars.deathStableTicks = 0;
+        vars.pauseHold = vars.unpauseHold = 0;
 
-        if (vars.deathStableTicks >= vars.DeathConfirmTicks)
-        {
-            if (!vars.is_paused) { vars.timerModel.Pause(); vars.is_paused = true; } // freeze immediately
-            vars.timer_started = false;
-            vars.hasStoppedOnce = true;
-            vars.pendingReset = true; // reset via reset{}
-            vars.deathStableTicks = 0;
-            vars.pauseHold = vars.unpauseHold = 0;
-
-            vars.blockStartUntilAlive = true; // don't allow start until alive again
-            vars.aliveStableTicks = 0;
-        }
+        vars.blockStartUntilAlive = true; // don't allow start until alive again
+        vars.aliveStableTicks = 0;
     }
+}
 
-    // 4b) HARD map restart: timer decreased while still in gameplay (reset even at 1–2s)
+void HandleHardRestart()
+{
     if (current.menu_state == 0 && current.timer < old.timer)
     {
         // Immediate LiveSplit reset to 0.00
         vars.timerModel.Reset();
 
         // Clear local state for a fresh attempt
-        vars.timer_started = false;
-        vars.is_paused = false;
-        vars.hasStoppedOnce = false;
-        vars.did_reset = true;
-
-        vars.pauseHold = vars.unpauseHold = 0;
-        vars.stallTicks = vars.resumeTicks = 0;
-        vars.stallPauseActive = false;
-        vars.freshGameConfirmTicks = 0;
+        ClearLocalState();
 
         // If restart followed a death, start is still gated by blockStartUntilAlive.
     }
+}
 
-    // 5) Fresh-game queued reset logic — kept for menu-based reloads only
+void HandleFreshGameReset()
+{
     if (!vars.timer_started && vars.hasStoppedOnce &&
         !vars.pendingReset && !vars.did_reset &&
         current.menu_state == 0 && current.timer <= vars.T_RESET_SMALL)
@@ -265,12 +304,12 @@ update
         if (!vars.timer_started)
             vars.freshGameConfirmTicks = 0;
     }
+}
 
-    // 6) Pause-stripped clock
+void UpdatePauseStrippedClock()
+{
     if (!vars.is_paused)
         vars.timer_value = current.timer - vars.timer_pause_length;
     else
         vars.timer_pause_length = current.timer - vars.timer_value;
-
-    return true;
 }


### PR DESCRIPTION
## Summary
- expose timer thresholds and debounce values through LiveSplit settings
- consolidate repeated reset code in a ClearLocalState helper and use HashSet for state codes
- refactor update loop into smaller helper methods for pause, resets, and clock handling

## Testing
- `python -m py_compile 'B01 Auto Splitter (plutonium).asl'` *(fails: SyntaxError: invalid decimal literal)*

------
https://chatgpt.com/codex/tasks/task_e_689ff57801b88330a346367b1a0980e1